### PR TITLE
Model Integration

### DIFF
--- a/scripts/state_comments.lean
+++ b/scripts/state_comments.lean
@@ -92,3 +92,5 @@ Prints the modified source code to stdout."
 /-- `lake exe state_comments` -/
 def main (args : List String) : IO UInt32 :=
   state_comments.validate args
+
+#eval main ["temp.temp"]

--- a/scripts/verifier.lean
+++ b/scripts/verifier.lean
@@ -2,15 +2,22 @@
 import Cli
 import scripts.state_comments
 
-open Lean Core Elab IO Meta Term Command Tactic
+open Lean Core Elab IO Meta Term Command Tactic Cli
 
 set_option autoImplicit true
 
--- we begin by configuring the modules/theorems we want to improve and the improver settings
--- improver settings are given by annotation, rag, best of n, refinement, etc. and metric config
--- metric config is given as in evaluate/metrics
--- theorems are given by a list of names, and modules are given by a list of names
+structure ImprovedTheoremInstance where
+  originalTheorem : String
+  modelOutput : String
+  stateComments : String
+  correct : Bool
+  metricScore : Nat
+  msgs : List String
 
+structure ImProverConfig where
+  mod : Name
+  decls : Option (List Name) := none
+  jsonPath : Option String := none
 
 def insert_state_comments (step:CompilationStep) (pre_elab_str: Option String := none) : IO String := do
   let mut trees := step.trees
@@ -24,7 +31,7 @@ def insert_state_comments (step:CompilationStep) (pre_elab_str: Option String :=
   /- **TODO**: I changed the logic in runAtDecls below, so now `step.src` is a substring of a different string,
     maybe (all preceding contents ++ this theorem). So the below (might) have to be changed -/
   let mut src := match pre_elab_str with
-                  | none => ({str:=step.src.str, stopPos := step.src.stopPos, startPos := 0} : Substring).toString.splitOn "\n"
+                  | none => step.src.toString.splitOn "\n"
                   | some str => (({str:=step.src.str, stopPos := step.src.startPos, startPos := 0} : Substring).toString ++ str).splitOn "\n"
   let mut inserted : Std.HashSet Nat := Std.HashSet.ofList [10000000]
   for item in L₃.reverse do
@@ -49,95 +56,168 @@ def _root_.Lean.Elab.Command.State.withOptions (state : Command.State) (options 
             opts := opts.insert k v
           opts } }
 
-/-- Our verifier needs two parts: First evaluate a whole module (for each module in config)
-with the proof as sorry option on. this should return a bunch of compilationSteps.
-Then on each decl in this module in the include list, we run the "improvement loop"
 
-This "loop" for will take in the now will literally just print out the
-theorem with the proof states interleaved.
+def promptModel (cmd : CompilationStep) (model : String := "nutPace/Improver-DeepSeek-R1-Distill-Qwen-7B_full")
+  (endpoint: String := "http://0.0.0.0:8000/v1/chat/completions") (best_of_n : Nat := 1) : IO (List String) := do
+  let srcCommand := cmd.src.toString
+  -- IO.println s!"srcCommand:\n{srcCommand.dropRightWhile (· == '\n')}"
 
-Then we will elaborate this string on the environment before the command which created that declaration.
-then we will print out the theorem with the proof states interleaved.
---/
+  let prompt : String := s!"Shorten the current theorem (wrapped in <CURRENT>...</CURRENT>) to be as short as possible in length - measured in the number of tactics in the proof - while also ensuring that the output is still a correct proof of the theorem. Include the output in the <IMPROVED>...</IMPROVED> tag.\n\n<CURRENT>\n{srcCommand}\n</CURRENT>\n\n<IMPROVED>"
+  let jsonPayload : Json := Json.mkObj [
+      ("model", Json.str model),
+      ("messages", Json.arr #[Json.mkObj [("role",Json.str "user"),("content", Json.str prompt)]]),
+      ("max_tokens", Json.num <| JsonNumber.fromNat 4096)
+    ]
+  let args := #[
+    "-X", "POST",
+    "-H", "Content-Type: application/json",
+    "-d", s!"{jsonPayload.compress}",
+    endpoint
+  ]
 
-def runAtDecls (mod : Name) (decls : Option (List Name) := none): IO Unit := do
+  let tasks := List.range (best_of_n) |>.map fun _ => IO.asTask (prio := Task.Priority.dedicated) do
+
+    let out_json ← IO.Process.output {
+      cmd := "curl",
+      args := args
+    }
+    return out_json
+
+  let newCommandCandidates ← tasks.mapM fun (t : BaseIO _) => do
+    IO.ofExcept <| (← t).get
+
+
+  let newCommandCandidates ← newCommandCandidates.mapM (fun out_json => do
+    let out_json_parsed : Json := (match Json.parse out_json.stdout with
+                          | Except.error _ => none
+                          | Except.ok msg => some msg).get!
+
+    let out := match out_json_parsed with
+              | Json.obj kvs => match kvs.find compare "choices" with
+                | some (Json.arr choices) => match choices[0]? with
+                  | some (Json.obj choice) => match choice.find compare "message" with
+                    | some (Json.obj message) => match message.find compare "content" with
+                      | some (Json.str s) => some s
+                      | _ => none
+                    | _ =>none
+                  | _ => none
+                | _ => none
+              | _ => none
+
+    let modelOutput := out.get!
+
+    let tagOpen  := "<IMPROVED>"
+    let tagClose := "</IMPROVED>"
+    let trimmed_out := modelOutput.stripPrefix tagOpen |>.stripSuffix tagClose
+
+    return trimmed_out)
+
+  return newCommandCandidates
+
+
+def promptModel_debug (cmd : CompilationStep) : IO (List String) := do
+  let srcCommand := cmd.src.toString
+  return ["--DEBUG\n"++srcCommand]
+
+
+def elaborateVariants (original : CompilationStep) (mod: Name) (variants : List String) : IO (List (Option (String × CompilationStep))) := do
+  let options := ({} : KVMap)
+      |>.insert `maxHeartbeats (.ofNat 200000) -- TODO determine a heartbeat count
+      |>.insert `debug.proofAsSorry (.ofBool false) -- turn proof checking back on
+
   let fileName := (← findLean mod).toString
 
+  let contentsBefore : Substring := match original.src with
+    | ⟨s, b, _⟩ => ⟨s, 0, b⟩
+
+  let tasks := variants.map fun newCommand => IO.asTask (prio := Task.Priority.dedicated) do
+    let elaborated_steps := Lean.Elab.IO.compilationSteps
+      (Parser.mkInputContext (contentsBefore.toString ++ newCommand) fileName)
+      original.parserStateBefore
+      (original.commandStateBefore.withOptions options)
+
+    let head? ← elaborated_steps.uncons
+    return match head? with
+      | none => none
+      | some (head, _) => some (newCommand,head)
+
+  let results ← tasks.mapM fun (t : BaseIO _) => do
+    IO.ofExcept <| (← t).get
+  return results
+
+
+def ImProver (config : ImProverConfig): IO Unit := do
+  let ⟨mod, decls, json_path⟩ := config
+  let fileName := (← findLean mod).toString
+  let mut trajectories_json := []
   /- TODO: I don't know if proofAsSorry is actually working -/
   let proofAsSorry := ({} : KVMap).insert `debug.proofAsSorry (.ofBool true)
   let steps := Lean.Elab.IO.processInput' (← moduleSource mod) none proofAsSorry fileName
 
   let targets := steps.bind fun c => (MLList.ofList c.diff).map fun i => (c, i)
-
   for (cmd, ci) in targets do
     if decls.isSome && !(decls.get!.contains ci.name) then
       continue
+    IO.println s!"============================================="
+    IO.println s!"Processing {ci.name} in {mod}"
+    IO.println s!"---------------------------------------------"
 
     for m in cmd.msgs do IO.eprintln (bombEmoji ++ (← m.data.toString))
     unless cmd.msgs.isEmpty do
       throw <| IO.userError s!"Unexpected messages in: {mod} during elaboration of {cmd.stx}"
 
-    let contentsBefore : Substring := match cmd.src with
-      | ⟨s, b, _⟩ => ⟨s, 0, b⟩
-    let srcCommand := cmd.src.toString
-    IO.println s!"COMPILATION STEP CONTENTS:\n{srcCommand.dropRightWhile (· == '\n')}"
+    -- let newCommandCandidates ← promptModel cmd (best_of_n := 5)
+    let newCommandCandidates ← promptModel_debug cmd
+    let resultantSteps := (← elaborateVariants cmd mod newCommandCandidates).filterMap (fun x => x)
 
-    /- Presumably, interaction with the LLM improver agent happens here.
-      Given e.g. the srcCommand (source theorem before improvement),
-      or e.g. ← insert_state_comments cmd (source theorem before improvement + state comments),
-      the LLM outputs its proof improvement candidates to newCommandCandidates.
-      Here we (1) don't do any changes and (2) replace rfl by sorry as a toy example. -/
-    let newCommandCandidates := [
-      srcCommand,
-      srcCommand.replace "rfl" "sorry"
-    ]
 
-    let options := ({} : KVMap)
-      |>.insert `maxHeartbeats (.ofNat 200000) -- TODO determine a heartbeat count
-      |>.insert `debug.proofAsSorry (.ofBool false) -- turn proof checking back on
 
-    /- Run proof candidates in parallel -/
-    let tasks := newCommandCandidates.map fun newCommand => IO.asTask do
-      let mut msgs := #[]
-      let mut correct := false
-      let elaborated_steps := Lean.Elab.IO.compilationSteps
-        (Parser.mkInputContext (contentsBefore.toString ++ newCommand) fileName)
-        cmd.parserStateBefore
-        (cmd.commandStateBefore.withOptions options)
 
-      let head? ← elaborated_steps.uncons
-      match head? with
-      | none =>
-        msgs := msgs.push s!"No elaborated steps"
-      | some (head, _) =>
-        -- Should probably check that ci is actually in the diff? But the below code is a bit finnicky with namespaces.
-        -- works fine without it anyways
+    let instances : List ImprovedTheoremInstance ← resultantSteps.mapM (fun (model_output,head) => do
+      let correct := head.msgs.isEmpty
+      let metric_score := head.trees.flatMap (fun tree=>tree.tactics) |>.length
+      let state_comments ← insert_state_comments head
 
-        -- if not (head.after.constants.map₂.contains ci.name) then
-        --   IO.eprintln s!"Expected {ci.name} to be in the elaborated steps, but it was not:\n {(head.diff.map (fun info=>info.name))}"
-        -- else
-        msgs := msgs.push s!"NEW COMMAND:\n{newCommand}"
-        msgs := msgs.push s!"CONSTANTS:\n{head.before.constants.map₂.toList.map (fun (x,v)=>x)}"
-        msgs := msgs.push s!"CONSTANTS:\n{head.after.constants.map₂.toList.map (fun (x,v)=>x)}"
-        msgs := msgs.push s!"AFTER ELAB CONTENTS:\n {← insert_state_comments head}"
+      let msgs ← head.msgs.mapM (fun msg => do
+        let m ← msg.data.toString
+        return bombEmoji++m)
 
-        /- Any errors in the improved proof will be caught here -/
-        for m in head.msgs do
-          msgs := msgs.push (bombEmoji ++ (← m.data.toString))
-        correct := head.msgs.isEmpty
+      return ⟨cmd.src.toString, model_output, state_comments, correct, metric_score, msgs⟩
+    )
 
-      return (correct, msgs)
 
-    let results ← tasks.mapM fun (t : BaseIO _) => do
-      IO.ofExcept <| (← t).get
-    for result in results do
-      IO.println "============================================="
-      let (correct, msgs) := result
+    for i in instances do
+      IO.println "-------------------------------------------------"
+      let ⟨original, newCommand,elabed, correct, metric, msgs⟩ := i
+      IO.println s!"Original:\n {original}"
+      IO.println s!"Model Output:\n {newCommand}"
+      IO.println s!"Compiled:\n {elabed}"
       IO.println s!"Correct: {correct}"
+      IO.println s!"Metric: {metric}"
       for msg in msgs do
         IO.println msg
+      IO.println "-------------------------------------------------"
+
+    let trajectories_json_new := instances.map (fun i =>
+      let ⟨original,newCmd,elabed, correct,metric,msgs⟩ := i
+      Json.mkObj [
+        ("module", Json.str mod.toString),
+        ("original", original),
+        ("new", Json.str newCmd),
+        ("annotated",Json.str elabed),
+        ("correct",Json.bool correct),
+        ("metric",Json.num <| JsonNumber.fromNat metric),
+        ("errors", Json.str ("\n\n".intercalate msgs))
+        ])
+    trajectories_json := trajectories_json ++ trajectories_json_new
+
+  let trajectories := Json.arr (trajectories_json.toArray)
+  match json_path with
+  | some path =>
+    IO.FS.writeFile path (trajectories.compress)
+  | none => pure ()
 
 
-#eval runAtDecls `temp.temp
 
-#eval runAtDecls `Mathlib.Logic.Hydra -- (some [`Relation.cutExpand_le_invImage_lex])
+
+#eval ImProver {mod:=`temp.temp, decls:= some [`theorem1]}

--- a/temp/temp.lean
+++ b/temp/temp.lean
@@ -1,51 +1,149 @@
-import Aesop
+import Mathlib.Data.Set.Lattice
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
 
-def p := True
-def q := True
-axiom p_eq_true : p = True
-axiom q_eq_true : q = True
+section
+variable {α : Type*}
+variable (s t u : Set α)
+open Set
 
-namespace TacticProofs
+theorem theorem1 : s ∩ t ∪ s ∩ u ⊆ s ∩ (t ∪ u) := by
+  rintro x (⟨xs, xt⟩ | ⟨xs, xu⟩)
+  · use xs; left; exact xt
+  · use xs; right; exact xu
 
-theorem list_eq_self1 (l : List α) : l = l := by
-  cases l
-  . have : p = True := by exact p_eq_true
-    rfl
-  . have : q = True := q_eq_true
-    rfl
+theorem theorem2 : s \ (t ∪ u) ⊆ (s \ t) \ u := by
+  rintro x ⟨xs, xntu⟩
+  constructor
+  use xs
+  · intro xt
+    exact xntu (Or.inl xt)
+  intro xu
+  apply xntu (Or.inr xu)
 
-theorem list_eq_self2 (α : Type) (l : List α) : l = l := by
-  exact list_eq_self1 l
+theorem theorem3 : s ∩ t = t ∩ s :=
+    Subset.antisymm
+    (fun x ⟨xs, xt⟩ ↦ ⟨xt, xs⟩) fun x ⟨xt, xs⟩ ↦ ⟨xs, xt⟩
 
-theorem list_eq_self3 (α : Type) (l : List α) : l = l := by
-  cases l <;> simp [p_eq_true, q_eq_true]
+theorem theorem4 : s ∩ (s ∪ t) = s := by
+  ext x; constructor
+  · rintro ⟨xs, _⟩
+    exact xs
+  · intro xs
+    use xs; left; exact xs
 
-theorem test1 (x : Nat) : x = x := by rfl
+theorem theorem5 : s ∪ s ∩ t = s := by
+  ext x; constructor
+  · rintro (xs | ⟨xs, xt⟩) <;> exact xs
+  · intro xs; left; exact xs
 
-theorem test2 (x : α) : x = x := by rfl
+theorem theorem6 : s \ t ∪ t = s ∪ t := by
+  ext x; constructor
+  · rintro (⟨xs, nxt⟩ | xt)
+    · left
+      exact xs
+    · right
+      exact xt
+  by_cases h : x ∈ t
+  · intro
+    right
+    exact h
+  rintro (xs | xt)
+  · left
+    use xs
+  right; exact xt
 
-theorem test3 (α : Type _) (x : α) : x = x := by rfl
+theorem theorem7 : s \ t ∪ t \ s = (s ∪ t) \ (s ∩ t) := by
+  ext x; constructor
+  · rintro (⟨xs, xnt⟩ | ⟨xt, xns⟩)
+    · constructor
+      left
+      exact xs
+      rintro ⟨_, xt⟩
+      contradiction
+    · constructor
+      right
+      exact xt
+      rintro ⟨xs, _⟩
+      contradiction
+  rintro ⟨xs | xt, nxst⟩
+  · left
+    use xs
+    intro xt
+    apply nxst
+    constructor <;> assumption
+  · right; use xt; intro xs
+    apply nxst
+    constructor <;> assumption
 
-theorem test4 (α : Type) (x : α) : x = x := by rfl
+theorem theorem8 : { n | Nat.Prime n } ∩ { n | n > 2 } ⊆ { n | ¬Even n } := by
+  intro n
+  simp
+  intro nprime n_gt
+  rcases Nat.Prime.eq_two_or_odd nprime with h | h
+  · rw [h]
+    linarith
+  · rw [Nat.odd_iff, h]
 
-theorem zero_eq_zero : 0 = 0 := by omega
+end
 
-theorem skolemizationTest1 (α : Type) [Inhabited α] (p : Prop) (f : α → Prop) (h : p ∨ ∃ x : α, f x) : p ∨ ∃ x : α, f x := by
-  exact h -- `skolemizeAll` can succeed because `α` is known to be inhabited
+section
 
-theorem skolemizationTest2 (α : Type) (p : Prop) (f : α → Prop) (h : p ∨ ∃ x : α, f x) : p ∨ ∃ x : α, f x := by
-  exact h -- `skolemizeAll` fails because `α` isn't known to be inhabited and the fact that `α` isn't inhabited doesn't follow from `h`
+variable (s t : Set ℕ)
 
-end TacticProofs
+section
+variable (ssubt : s ⊆ t)
 
-namespace TermProofs
+example (h₀ : ∀ x ∈ t, ¬Even x) (h₁ : ∀ x ∈ t, Prime x) : ∀ x ∈ s, ¬Even x ∧ Prime x := by
+  intro x xs
+  constructor
+  · apply h₀ x (ssubt xs)
+  apply h₁ x (ssubt xs)
 
-theorem termProof1 : 0 = 0 := rfl
+example (h : ∃ x ∈ s, ¬Even x ∧ Prime x) : ∃ x ∈ t, Prime x := by
+  rcases h with ⟨x, xs, _, px⟩
+  use x, ssubt xs
 
-theorem termProof2 (x : Nat) : x + 0 = x := Nat.add_zero x
+end
 
-theorem termProof3 (p q : Prop) (h : p → q) (hp : p) : q := h hp
+end
 
-theorem termProof4 (b : Prop) (h : a → b) : a → b := h
+section
+variable {α I : Type*}
+variable (A B : I → Set α)
+variable (s : Set α)
 
-end TermProofs
+open Set
+
+theorem theorem9 : (s ∪ ⋂ i, A i) = ⋂ i, A i ∪ s := by
+  ext x
+  simp only [mem_union, mem_iInter]
+  constructor
+  · rintro (xs | xI)
+    · intro i
+      right
+      exact xs
+    intro i
+    left
+    exact xI i
+  intro h
+  by_cases xs : x ∈ s
+  · left
+    exact xs
+  right
+  intro i
+  cases h i
+  · assumption
+  contradiction
+
+def primes : Set ℕ :=
+  { x | Nat.Prime x }
+
+theorem theorem10 : (⋃ p ∈ primes, { x | x ≤ p }) = univ := by
+  apply eq_univ_of_forall
+  intro x
+  simp
+  rcases Nat.exists_infinite_primes x with ⟨p, pge, primep⟩
+  use p, primep
+
+end


### PR DESCRIPTION
## Changes:
- added `curl` interface to call out for vLLM endpoints
- Made quick evaluation interface to output json data 
- Modified all threads/tasks to use `prio:=Task.Priority.dedicated` to ensure no cpu core bottlenecks
- restructured file to use standardized configuration objects and outputs
- added debug option for model prompting.

## Bugs/TODO:
- need to double check if `debug.proofAsSorry` is working.
- weird issue on `temp.temp` `theorem3` where unused vars are causing an issue raised on line 166-167
- fix up the config and instance objects to be better datastructures and have more robust information
- fix metric (completely wrong: currently is `flatMap`'ing over all infotrees of a `CompilationStep` and adding up the tactics.
- fix state comments: Used to work, now isn't always adding state comments, even on easy examples (see `temp.temp` `theorem1`