### PR TITLE
Add scripts for class-3 KG edges

### DIFF
--- a/ImProver/C1Graph/build_combined_db.py
+++ b/ImProver/C1Graph/build_combined_db.py
@@ -1,0 +1,83 @@
+import os
+import json
+import argparse
+import duckdb
+from tqdm import tqdm
+
+
+def load_edges(path):
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def main(args):
+    os.makedirs(os.path.join(args.KG_dir, "class3"), exist_ok=True)
+    combined_path = os.path.join(args.KG_dir, "class3", "combined.duckdb")
+    con = duckdb.connect(combined_path)
+    con.execute("DROP TABLE IF EXISTS theorems")
+    con.execute(
+        """
+        CREATE TABLE theorems(
+            module TEXT,
+            name TEXT,
+            text TEXT,
+            isExtracted BOOLEAN,
+            isOriginal BOOLEAN,
+            C1Dependencies JSON,
+            C2Dependencies JSON,
+            C3Dependencies JSON
+        )
+        """
+    )
+
+    class3_edges = load_edges(os.path.join(args.KG_dir, "class3", "class3_edges.json"))
+
+    with open(args.dataset_path, "r") as f:
+        all_ds = json.load(f)
+        dataset = all_ds[args.split]
+    files = []
+    for repo in dataset.values():
+        files.extend(repo)
+    modules = set(f.replace(".lean", "").replace("/", ".") for f in files)
+
+    for root, _, files in os.walk(args.KG_dir):
+        for file in files:
+            if not file.endswith(".json"):
+                continue
+            if "filtered" in root and "config" in file:
+                continue
+            module_path = os.path.relpath(os.path.join(root, file), args.KG_dir)
+            module = module_path.replace("/", ".").replace(".json", "")
+            with open(os.path.join(root, file), "r") as f:
+                theorems = json.load(f)
+            for thm in theorems:
+                name = thm.get("name")
+                is_orig = thm.get("module", module) in modules
+                c1 = json.dumps(thm.get("C1_dependencies", []))
+                c2 = json.dumps(thm.get("C2_dependencies", []))
+                c3 = json.dumps(class3_edges.get(f"{module}:{name}", []))
+                con.execute(
+                    "INSERT INTO theorems VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        module,
+                        name,
+                        thm.get("text"),
+                        thm.get("isExtracted", False),
+                        is_orig,
+                        c1,
+                        c2,
+                        c3,
+                    ),
+                )
+    con.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build combined KG database")
+    parser.add_argument("dataset_path", type=str)
+    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--KG_dir", type=str, default="KG2.75")
+    args = parser.parse_args()
+    main(args)

--- a/ImProver/C1Graph/build_vector_db.py
+++ b/ImProver/C1Graph/build_vector_db.py
@@ -1,0 +1,47 @@
+import os
+import argparse
+import duckdb
+from chromadb import PersistentClient
+from chromadb.utils import embedding_functions
+
+
+def build_db(db_path, out_dir, model="intfloat/e5-base-v2"):
+    con = duckdb.connect(db_path, read_only=True)
+    rows = con.execute(
+        "SELECT module, name, text, informal_statement, informal_proof, isExtracted, isOriginal FROM informal_data"
+    ).fetchall()
+    con.close()
+
+    os.makedirs(out_dir, exist_ok=True)
+    client = PersistentClient(path=out_dir)
+    embed = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=model)
+    collection = client.get_or_create_collection("informal_theorems", embedding_function=embed)
+
+    documents, metadatas, ids = [], [], []
+    for idx, row in enumerate(rows):
+        module, name, text, stmt, proof, is_ex, is_orig = row
+        doc = f"{text}\n\n{stmt}\n\n{proof}"
+        metadata = {
+            "module": module,
+            "name": name,
+            "text": text,
+            "informal_statement": stmt,
+            "informal_proof": proof,
+            "isExtracted": is_ex,
+            "isOriginal": is_orig,
+        }
+        documents.append(doc)
+        metadatas.append(metadata)
+        ids.append(f"{module}:{name}")
+    if documents:
+        collection.add(documents=documents, metadatas=metadatas, ids=ids)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build vector DB for informal theorems")
+    parser.add_argument("db_path", type=str, help="Path to informal duckdb")
+    parser.add_argument("--out_dir", type=str, default="chroma_db")
+    parser.add_argument("--model", type=str, default="intfloat/e5-base-v2")
+    args = parser.parse_args()
+
+    build_db(args.db_path, args.out_dir, args.model)

--- a/ImProver/C1Graph/compute_class3_edges.py
+++ b/ImProver/C1Graph/compute_class3_edges.py
@@ -1,0 +1,41 @@
+import os
+import json
+import argparse
+import duckdb
+from chromadb import PersistentClient
+
+
+def main(args):
+    con = duckdb.connect(args.db_path, read_only=True)
+    rows = con.execute("SELECT module, name, informal_statement, informal_proof FROM informal_data").fetchall()
+    con.close()
+
+    client = PersistentClient(path=args.chroma_dir)
+    collection = client.get_collection("informal_theorems")
+
+    edges = {}
+    for module, name, stmt, proof in rows:
+        query = f"{stmt}\n\n{proof}".strip()
+        if not query:
+            continue
+        res = collection.query(query_texts=[query], n_results=args.k)
+        deps = []
+        for dep_id, score in zip(res["ids"][0], res["distances"][0]):
+            if score <= args.threshold:
+                dep_meta = collection.get(id=dep_id)["metadatas"][0]
+                deps.append({"module": dep_meta["module"], "name": dep_meta["name"]})
+        edges[f"{module}:{name}"] = deps
+
+    out_path = os.path.join(os.path.dirname(args.db_path), "class3_edges.json")
+    with open(out_path, "w") as f:
+        json.dump(edges, f, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Compute class3 edges")
+    parser.add_argument("db_path", type=str, help="Path to informal duckdb")
+    parser.add_argument("chroma_dir", type=str, help="Path to chroma db")
+    parser.add_argument("--k", type=int, default=5)
+    parser.add_argument("--threshold", type=float, default=0.5)
+    args = parser.parse_args()
+    main(args)

--- a/ImProver/C1Graph/informalize.py
+++ b/ImProver/C1Graph/informalize.py
@@ -1,0 +1,139 @@
+import os
+import json
+import re
+import argparse
+from tqdm import tqdm
+import pandas as pd
+import duckdb
+import ray
+from ray.data.llm import build_llm_processor, vLLMEngineProcessorConfig
+from ray.data import DataContext
+
+
+def build_prompt(thm, include_context=False):
+    context = ""
+    if include_context:
+        deps = thm.get("C1_dependencies", [])
+        dep_texts = "\n\n".join(d.get("text", "").strip() for d in deps)
+        if dep_texts:
+            context = f"<CONTEXT>\n{dep_texts}\n</CONTEXT>\n"
+    theorem_text = thm.get("text", "").strip()
+    prompt = (
+        f"<THEOREM>\n{theorem_text}\n</THEOREM>\n"
+        f"{context}"
+        "Provide an informal statement and proof following the formal proof step by step."
+        " Wrap the statement in <INFORMAL_STATEMENT> tags and the proof in <INFORMAL_PROOF> tags."
+    )
+    return prompt
+
+
+def collect_prompts(kg_dir, dataset_path, split="train", include_context=False):
+    with open(dataset_path, "r") as f:
+        all_ds = json.load(f)
+        dataset = all_ds[split]
+    files = []
+    for repo in dataset.values():
+        files.extend(repo)
+    modules = set(f.replace(".lean", "").replace("/", ".") for f in files)
+
+    prompts = []
+    for root, _, files in os.walk(kg_dir):
+        for file in files:
+            if not file.endswith(".json"):
+                continue
+            if "filtered" in root and "config" in file:
+                continue
+            module_path = os.path.relpath(os.path.join(root, file), kg_dir)
+            module = module_path.replace("/", ".").replace(".json", "")
+            with open(os.path.join(root, file), "r") as f:
+                theorems = json.load(f)
+            for thm in theorems:
+                thm_module = thm.get("module", module)
+                if thm_module not in modules:
+                    continue
+                prompt = build_prompt(thm, include_context)
+                prompts.append({
+                    "prompt": prompt,
+                    "module": thm_module,
+                    "name": thm.get("name"),
+                    "text": thm.get("text"),
+                    "isExtracted": thm.get("isExtracted", False),
+                    "isOriginal": True,
+                })
+    return pd.DataFrame(prompts)
+
+
+def run_inference(df, args):
+    os.environ["NCCL_P2P_DISABLE"] = "1"
+    ray.init(num_cpus=args.cpus, num_gpus=args.gpus)
+    DataContext.get_current().wait_for_min_actors_s = 1800
+
+    config = vLLMEngineProcessorConfig(
+        model_source=args.model,
+        engine_resources={"CPU": max(1, args.cpus // max(1, args.gpus)), "GPU": 1},
+        concurrency=max(1, args.gpus),
+        engine_kwargs={
+            "tensor_parallel_size": 1,
+            "enable_chunked_prefill": True,
+            "max_model_len": 16384,
+            "max_num_batched_tokens": 65536,
+        },
+        max_concurrent_batches=32,
+        batch_size=32,
+    )
+
+    processor = build_llm_processor(
+        config,
+        preprocess=lambda row: dict(
+            messages=[{"role": "user", "content": row["prompt"]}],
+            sampling_params=dict(truncate_prompt_tokens=16384 - 512, max_tokens=512),
+        ),
+        postprocess=lambda row: dict(answer=row["generated_text"], **row),
+    )
+
+    ds = ray.data.from_pandas(df).repartition(max(1, args.gpus) * 4)
+    ds = processor(ds).materialize()
+
+    output_dir = os.path.join(args.KG_dir, "class3", "data")
+    os.makedirs(output_dir, exist_ok=True)
+    ds.write_parquet(f"local://{output_dir}")
+    return output_dir
+
+
+def populate_database(output_dir, kg_dir):
+    db_path = os.path.join(kg_dir, "class3", "informal_data.duckdb")
+    con = duckdb.connect(db_path)
+    con.execute("DROP TABLE IF EXISTS informal_data")
+    con.execute(f"CREATE TABLE informal_data AS SELECT * FROM read_parquet('{output_dir}/*.parquet')")
+    con.execute("ALTER TABLE informal_data ADD COLUMN IF NOT EXISTS informal_statement TEXT")
+    con.execute("ALTER TABLE informal_data ADD COLUMN IF NOT EXISTS informal_proof TEXT")
+    rows = con.execute("SELECT rowid, answer FROM informal_data").fetchall()
+    for rowid, answer in tqdm(rows, desc="Parsing outputs"):
+        stmt_match = re.search(r"<INFORMAL_STATEMENT>([\s\S]*?)</INFORMAL_STATEMENT>", answer)
+        proof_match = re.search(r"<INFORMAL_PROOF>([\s\S]*?)</INFORMAL_PROOF>", answer)
+        stmt = stmt_match.group(1).strip() if stmt_match else ""
+        proof = proof_match.group(1).strip() if proof_match else ""
+        con.execute(
+            "UPDATE informal_data SET informal_statement=?, informal_proof=? WHERE rowid=?",
+            (stmt, proof, rowid),
+        )
+    con.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Informalize theorems")
+    parser.add_argument("dataset_path", type=str)
+    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--KG_dir", type=str, default="KG2.75")
+    parser.add_argument("--include_context", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--model", type=str, default="deepseek-ai/DeepSeek-R1-Distill-Qwen-7B")
+    parser.add_argument("--cpus", type=int, default=4)
+    parser.add_argument("--gpus", type=int, default=1)
+    args = parser.parse_args()
+
+    df = collect_prompts(args.KG_dir, args.dataset_path, args.split, args.include_context)
+    if len(df) == 0:
+        print("No theorems to process")
+        exit()
+    output_dir = run_inference(df, args)
+    populate_database(output_dir, args.KG_dir)

--- a/ImProver/C1Graph/makeKG_3.py
+++ b/ImProver/C1Graph/makeKG_3.py
@@ -1,0 +1,80 @@
+import os
+import json
+import argparse
+import duckdb
+from neo4j import GraphDatabase
+from tqdm import tqdm
+
+
+def init_node(tx, theorem):
+    tx.run(
+        """
+        MERGE (t:Theorem {name: $name, module: $module})
+        SET t.text = $text
+        SET t.isExtracted = $isExtracted
+        SET t.isOriginal = $isOriginal
+        """,
+        name=theorem["name"],
+        text=theorem["text"],
+        module=theorem["module"],
+        isExtracted=theorem["isExtracted"],
+        isOriginal=theorem["isOriginal"],
+    )
+
+
+def create_edges(tx, thm, deps, rel):
+    for dep in deps:
+        tx.run(
+            """
+            MATCH (t:Theorem {name: $theorem_name, module: $theorem_module})
+            MATCH (d:Theorem {name: $dep_name, module: $dep_module})
+            MERGE (t)-[r:%s]->(d)
+            """ % rel,
+            theorem_name=thm["name"],
+            theorem_module=thm["module"],
+            dep_name=dep["name"],
+            dep_module=dep["module"],
+        )
+
+
+def process_row(tx, row):
+    thm = {
+        "name": row["name"],
+        "module": row["module"],
+        "text": row["text"],
+        "isExtracted": row["isExtracted"],
+        "isOriginal": row["isOriginal"],
+    }
+    c1 = json.loads(row["C1Dependencies"]) if row["C1Dependencies"] else []
+    c2 = json.loads(row["C2Dependencies"]) if row["C2Dependencies"] else []
+    c3 = json.loads(row["C3Dependencies"]) if row["C3Dependencies"] else []
+
+    init_node(tx, thm)
+    for dep in c1 + c2 + c3:
+        init_node(tx, dep)
+
+    create_edges(tx, thm, c1, "DEPENDS_ON")
+    create_edges(tx, thm, c2, "DEPENDS_ON")
+    create_edges(tx, thm, c3, "INFORMALLY_DEPENDS_ON")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export KG with class3 edges")
+    parser.add_argument("db_path", type=str, help="Path to combined duckdb")
+    parser.add_argument("--neo4j_uri", type=str, default="bolt://localhost:7687")
+    parser.add_argument("--neo4j_user", type=str, default="neo4j")
+    parser.add_argument("--neo4j_pass", type=str, default="12345678")
+    args = parser.parse_args()
+
+    driver = GraphDatabase.driver(args.neo4j_uri, auth=(args.neo4j_user, args.neo4j_pass))
+    con = duckdb.connect(args.db_path, read_only=True)
+    rows = con.execute("SELECT * FROM theorems").fetchall()
+    cols = [c[0] for c in con.execute("PRAGMA table_info('theorems')").fetchall()]
+    con.close()
+
+    with driver.session() as session:
+        for row in tqdm(rows, desc="Uploading"):
+            row_dict = dict(zip(cols, row))
+            session.write_transaction(process_row, row_dict)
+
+    driver.close()


### PR DESCRIPTION
## Summary
- implement `informalize.py` to generate informal theorem statements and proofs
- add `build_vector_db.py` for embedding informal theorems into a Chroma DB
- script `compute_class3_edges.py` computes similarity-based dependencies
- script `build_combined_db.py` aggregates C1, C2 and new C3 edges
- new `makeKG_3.py` exports the combined graph to Neo4j

## Testing
- `python -m py_compile ImProver/C1Graph/informalize.py ImProver/C1Graph/build_vector_db.py ImProver/C1Graph/makeKG_3.py ImProver/C1Graph/compute_class3_edges.py ImProver/C1Graph/build_combined_db.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_68488f05196c83308c57f84b5e12771b