### PR TITLE
Add dynamic parser usage in CLI

### DIFF
--- a/ImProver/KG/build_combined_db.py
+++ b/ImProver/KG/build_combined_db.py
@@ -115,11 +115,98 @@ def main(args):
     con.close()
 
 
-if __name__ == "__main__":
+def get_parser() -> argparse.ArgumentParser:
+    """Return the parser for building the combined KG database."""
     parser = argparse.ArgumentParser(description="Build combined KG database")
     parser.add_argument("dataset_path", type=str)
     parser.add_argument("KG_id", type=str)
     parser.add_argument("--split", type=str, default="train")
     parser.add_argument("--KG_dir", type=str, default=".knowledge_graphs")
-    args = parser.parse_args()
-    main(args)
+    return parser
+
+
+def main(args=None):
+    if args is None:
+        parser = get_parser()
+        args = parser.parse_args()
+    main_func(args)
+
+
+def main_func(args):
+    os.makedirs(os.path.join(args.KG_dir, args.KG_id), exist_ok=True)
+    combined_path = os.path.join(args.KG_dir, args.KG_id, "combined.duckdb")
+    con = duckdb.connect(combined_path)
+    con.execute("DROP TABLE IF EXISTS theorems")
+    con.execute(
+        """
+        CREATE TABLE theorems(
+            module TEXT,
+            name TEXT,
+            text TEXT,
+            informalStatement TEXT,
+            informalProof TEXT,
+            isExtracted BOOLEAN,
+            isOriginal BOOLEAN,
+            isCorrect BOOLEAN,
+            errorMsgs JSON,
+            C1Dependencies JSON,
+            C2Dependencies JSON,
+            C3Dependencies JSON
+        )
+        """
+    )
+
+    class3_edges = load_edges(os.path.join(args.KG_dir, args.KG_id, "c3edges.json"))
+
+    with open(args.dataset_path, "r") as f:
+        all_ds = json.load(f)
+        dataset = all_ds[args.split]
+    files = []
+    for repo in dataset.values():
+        files.extend(repo)
+
+    files_real = [file_info if type(file_info) is str else file_info["file"] for file_info in files]
+    modules = set(f.replace(".lean", "").replace("/", ".") for f in files_real)
+
+    informal_path = os.path.join(args.KG_dir, args.KG_id, "informal_data.duckdb")
+    informal_con = duckdb.connect(informal_path)
+
+    for root, _, files in os.walk(args.KG_dir):
+        for file in files:
+            if not file.endswith(".json"):
+                continue
+            if file == "config.json":
+                continue
+            module_path = os.path.relpath(os.path.join(root, file), args.KG_dir)
+            module = module_path.replace("/", ".").replace(".json", "")
+            with open(os.path.join(root, file), "r") as f:
+                theorems = json.load(f)
+            for thm in theorems:
+                thm_module = thm.get("id", {}).get("module", module)
+                if thm_module not in modules:
+                    continue
+                stmt = thm.get("informal_statement", "")
+                proof = thm.get("informal_proof", "")
+                c3 = class3_edges.get(f"{thm_module}:{thm.get('id', {}).get('name')}", [])
+                con.execute(
+                    "INSERT INTO theorems VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        thm_module,
+                        thm.get("id", {}).get("name"),
+                        thm.get("id", {}).get("content"),
+                        stmt,
+                        proof,
+                        thm.get("isExtracted", False),
+                        thm.get("isOriginal", False),
+                        thm.get("isCorrect", False),
+                        thm.get("errorMessages", []),
+                        json.dumps(thm.get("C1_dependencies", [])),
+                        json.dumps(thm.get("C2_dependencies", [])),
+                        json.dumps(c3),
+                    ),
+                )
+    con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ImProver/KG/build_vector_db.py
+++ b/ImProver/KG/build_vector_db.py
@@ -64,20 +64,32 @@ def build_db(db_path, out_dir, model):
             gc.collect()
 
 
-if __name__ == "__main__":
+def get_parser() -> argparse.ArgumentParser:
+    """Return the argument parser used for building the vector database."""
+    parser = argparse.ArgumentParser(description="Build vector DB for informal theorems")
+    parser.add_argument("prompts_id", type=str)
+    parser.add_argument("KG_id", type=str, nargs="?", default="KG_" + datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    parser.add_argument("--prompts_dir", type=str, default=".prompts")
+    parser.add_argument("--KG_dir", type=str, default=".knowledge_graphs")
+    parser.add_argument("--model", type=str, default="Qwen/Qwen3-Embedding-0.6B")
+    return parser
+
+
+def main(args=None):
+    if args is None:
+        parser = get_parser()
+        args = parser.parse_args()
+
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
         torch.cuda.ipc_collect()
     gc.collect()
-    parser = argparse.ArgumentParser(description="Build vector DB for informal theorems")
-    parser.add_argument("prompts_id", type=str)
-    parser.add_argument("KG_id", type=str, nargs='?', default="KG_"+datetime.now().strftime("%Y%m%d_%H%M%S"))
-    parser.add_argument("--prompts_dir", type=str, default=".prompts")
-    parser.add_argument("--KG_dir", type=str, default=".knowledge_graphs")
-    # parser.add_argument("--out_dir", type=str, default="chroma_db")
-    parser.add_argument("--model", type=str, default="Qwen/Qwen3-Embedding-0.6B")
-    args = parser.parse_args()
+
     db_path = os.path.join(args.prompts_dir, args.prompts_id, "informal_data.duckdb")
     out_dir = os.path.join(args.KG_dir, args.KG_id, "chroma_db")
 
     build_db(db_path, out_dir, args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/ImProver/KG/compute_class3_edges.py
+++ b/ImProver/KG/compute_class3_edges.py
@@ -7,10 +7,30 @@ from chromadb import PersistentClient
 from chromadb.utils import embedding_functions
 import torch
 
-def main(args):
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Return the parser for computing class3 edges."""
+    parser = argparse.ArgumentParser(description="Compute class3 edges")
+    parser.add_argument("KG_id", type=str)
+    parser.add_argument("--KG_dir", type=str, default=".knowledge_graphs")
+    parser.add_argument("--model", type=str, default="Qwen/Qwen3-Embedding-0.6B")
+    parser.add_argument("--k", type=int, default=40)
+    parser.add_argument("--threshold", type=float, default=0.35)
+    return parser
+
+
+def main(args=None):
+    if args is None:
+        parser = get_parser()
+        args = parser.parse_args()
+    main_func(args)
+
+
+def main_func(args):
     db_path = os.path.join(args.KG_dir, args.KG_id, "informal_data.duckdb")
     chroma_dir = os.path.join(args.KG_dir, args.KG_id, "chroma_db")
-    
+
     con = duckdb.connect(db_path, read_only=True)
     rows = con.execute("SELECT module, name, informal_statement, informal_proof FROM informal_data").fetchall()
     con.close()
@@ -18,11 +38,8 @@ def main(args):
     client = PersistentClient(path=chroma_dir)
     embed = embedding_functions.SentenceTransformerEmbeddingFunction(
         model_name=args.model,
-        device="cuda",                      # push model to available GPU(s)
-        model_kwargs={
-            "device_map": "cuda:0",           # shard across multiple GPUs if present
-            "torch_dtype": torch.float16    # cut VRAM/RAM usage in half
-        }
+        device="cuda",
+        model_kwargs={"device_map": "cuda:0", "torch_dtype": torch.float16},
     )
     collection = client.get_or_create_collection("informal_theorems", embedding_function=embed)
 
@@ -37,16 +54,14 @@ def main(args):
             if score <= args.threshold:
                 dep_meta = collection.get(ids=[dep_id])["metadatas"][0]
                 dep_name = dep_meta["name"]
-                
-                # Skip if the retrieved item has the same name
+
                 if dep_name == name:
                     continue
-                
-                # Check for "extracted_split_{realName}_{some numbers}" pattern
+
                 match = re.match(r"extracted_split_(.+?)_\d+$", dep_name)
                 if match and match.group(1) == name:
                     continue
-                
+
                 deps.append({"module": dep_meta["module"], "name": dep_name})
         edges[f"{module}:{name}"] = deps
         print(f"Processed {module}:{name} with {len(deps)} dependencies")
@@ -57,13 +72,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Compute class3 edges")
-    parser.add_argument("KG_id", type=str)
-    parser.add_argument("--KG_dir", type=str, default=".knowledge_graphs")
-    # parser.add_argument("--chroma_dir", type=str, default = "chroma_db", help="Path to chroma db")
-    parser.add_argument("--model", type=str, default="Qwen/Qwen3-Embedding-0.6B")
-
-    parser.add_argument("--k", type=int, default=40)
-    parser.add_argument("--threshold", type=float, default=0.35)
-    args = parser.parse_args()
-    main(args)
+    main()

--- a/ImProver/KG/heuristic_filter.py
+++ b/ImProver/KG/heuristic_filter.py
@@ -587,8 +587,8 @@ def main(args):
     
 
 
-if __name__ == "__main__":
-
+def get_parser() -> argparse.ArgumentParser:
+    """Return the parser for filtering the knowledge graph."""
     parser = argparse.ArgumentParser(description="Filter KG for ImProver")
     parser.add_argument("KG_id", type=str)
 
@@ -634,13 +634,59 @@ if __name__ == "__main__":
     parser.add_argument(
         "--training_data", action=argparse.BooleanOptionalAction , type=bool, default=True, help="Whether to generate training data (default: True)"
     )
+    return parser
 
-    args = parser.parse_args()
 
-    # ------------------------------------------------------------------
-    # Initialise tokenizer once so we can measure prompt lengths
+def main(args=None):
+    parser = get_parser()
+    if args is None:
+        args = parser.parse_args()
+
     MAX_PROMPT_TOKENS = 16384 - 512   # model context minus generation tokens
     tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=True)
-    # ------------------------------------------------------------------
 
-    main(args)
+    main_func(args, tokenizer, MAX_PROMPT_TOKENS)
+
+
+def main_func(args, tokenizer, MAX_PROMPT_TOKENS):
+    if args.run_inference:
+
+        combined_dataset_path = os.path.join(args.KG_dir, args.KG_id, "combined.duckdb")
+        con = duckdb.connect(combined_dataset_path)
+
+        df_raw = con.execute("SELECT * FROM theorems").df()
+
+        prompts = []
+        truncation_count = 0
+        for _, row in df_raw.iterrows():
+            thm_prompt = get_thm_prompt(row.to_dict())
+            if thm_prompt is None:
+                continue
+
+            tokens = tokenizer.encode(thm_prompt["raw_prompt"], add_special_tokens=False)
+            if len(tokens) > MAX_PROMPT_TOKENS:
+                tokens = tokens[-MAX_PROMPT_TOKENS:]
+                thm_prompt["raw_prompt"] = tokenizer.decode(tokens)
+                truncation_count += 1
+
+            prompts.append(thm_prompt)
+
+        print(f"Total prompts: {len(prompts)}")
+        print(f"Truncated prompts: {truncation_count}")
+        df = pd.DataFrame(prompts)
+
+        output_path = run_inference(df, args)
+        print(f"Run inference complete. Output saved to {output_path}")
+
+    database_path = os.path.join(args.KG_dir, args.KG_id, "filtered_data.duckdb")
+    con = duckdb.connect(database_path)
+    if args.augment_DB:
+        construct_KG_data(con, args)
+        print("Constructed KG data and updated run_data table.")
+    if args.training_data:
+        get_training_dataset(con, args)
+        print("Generated training dataset and saved to training.jsonl.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ImProver/KG/informalize.py
+++ b/ImProver/KG/informalize.py
@@ -88,8 +88,9 @@ Thus, we have a contradiction, and therefore $p$ must be greater than $n$.
 
 Now, with this example in mind, informalize the following theorem and proof, which is wrapped in <FORMAL>...</FORMAL> tags, and be sure to wrap your informal statement in <STATEMENT>...</STATEMENT> tags and your informal proof in <PROOF>...</PROOF> tags.
 
-{context + "\n\n" if include_context else ""}<FORMAL>\n{theorem_text}\n</FORMAL>
 """
+    context_block = context + "\n\n" if include_context else ""
+    prompt += f"{context_block}<FORMAL>\n{theorem_text}\n</FORMAL>"
     
     
 
@@ -200,7 +201,8 @@ def populate_database(output_dir, prompts_dir):
     con.close()
 
 
-if __name__ == "__main__":
+def get_parser() -> argparse.ArgumentParser:
+    """Return the parser for informalizing theorems."""
     parser = argparse.ArgumentParser(description="Informalize theorems")
     parser.add_argument("dataset_path", type=str)
     parser.add_argument("prompts_id", type=str)
@@ -226,14 +228,24 @@ if __name__ == "__main__":
         default=available_gpus,
         help="Number of GPUs to use (default: all available)",
     )
-    args = parser.parse_args()
-    
+    return parser
+
+
+def main(args=None):
+    parser = get_parser()
+    if args is None:
+        args = parser.parse_args()
+
     MAX_PROMPT_TOKENS = 16384 - 2048   # model context minus generation tokens
     tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=True)
 
-    df = collect_prompts(os.path.join(args.prompts_dir,args.prompts_id,"src"), args.dataset_path, args.split, args.include_context)
+    df = collect_prompts(os.path.join(args.prompts_dir, args.prompts_id, "src"), args.dataset_path, args.split, args.include_context)
     if len(df) == 0:
         print("No theorems to process")
-        exit()
+        return
     output_dir = run_inference(df, args)
-    populate_database(output_dir, os.path.join(args.prompts_dir,args.prompts_id))
+    populate_database(output_dir, os.path.join(args.prompts_dir, args.prompts_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/ImProver/KG/insert_neo4j.py
+++ b/ImProver/KG/insert_neo4j.py
@@ -218,15 +218,47 @@ def remove_informal_cycles(session):
     else:
         print("No bidirectional INFORMALLY_DEPENDS_ON relationships found")
 
-if __name__ == "__main__":
+def get_parser() -> argparse.ArgumentParser:
+    """Return the parser for inserting the KG into Neo4j."""
     parser = argparse.ArgumentParser(description="Export KG with class3 edges")
     parser.add_argument("KG_id", type=str)
-
     parser.add_argument("KG_dir", type=str, help="Path to KG directory")
     parser.add_argument("--neo4j_uri", type=str, default="bolt://localhost:7687")
     parser.add_argument("--neo4j_user", type=str, default="neo4j")
     parser.add_argument("--neo4j_pass", type=str, default="12345678")
-    args = parser.parse_args()
+    return parser
+
+
+def main(args=None):
+    parser = get_parser()
+    if args is None:
+        args = parser.parse_args()
+
+    driver = GraphDatabase.driver(args.neo4j_uri, auth=(args.neo4j_user, args.neo4j_pass))
+
+    db_path = os.path.join(args.KG_dir, args.KG_id, "combined.duckdb")
+
+    con = duckdb.connect(db_path, read_only=True)
+    rows = con.execute("SELECT * FROM theorems").fetchall()
+    cols = [c[1] for c in con.execute("PRAGMA table_info('theorems')").fetchall()]
+    con.close()
+
+    filtered_path = os.path.join(args.KG_dir, args.KG_id, "filtered_data.duckdb")
+    con = duckdb.connect(filtered_path, read_only=True)
+
+    with driver.session() as session:
+        for row in tqdm(rows, desc="Uploading"):
+            row_dict = dict(zip(cols, row))
+            session.write_transaction(process_row, row_dict, con)
+
+        print("Checking for cycles in INFORMALLY_DEPENDS_ON relationships...")
+        remove_informal_cycles(session)
+
+    driver.close()
+
+
+if __name__ == "__main__":
+    main()
 
     driver = GraphDatabase.driver(args.neo4j_uri, auth=(args.neo4j_user, args.neo4j_pass))
     

--- a/ImProver/analysis.py
+++ b/ImProver/analysis.py
@@ -497,12 +497,20 @@ def run_training_analysis(run_id, run_dir_path, config):
     print("Training data extraction finished.")
 
 
-def main():
+def get_parser() -> argparse.ArgumentParser:
+    """Return the argument parser used for analysis."""
     parser = argparse.ArgumentParser(description="Perform analysis on experimental run data.")
     parser.add_argument("RunID", help="Identifier for the run.")
-    parser.add_argument("--run_dir", help="Path to the run directory (default: .evals/).", default=".evals/")
-    parser.add_argument("--training_data", action=argparse.BooleanOptionalAction, help="Whether to extract training data (default: True)", default=True)
-    args = parser.parse_args()
+    parser.add_argument("--run_dir", default=".evals/", help="Path to the run directory (default: .evals/)")
+    parser.add_argument("--training_data", action=argparse.BooleanOptionalAction, default=True,
+                        help="Whether to extract training data (default: True)")
+    return parser
+
+
+def main(args=None):
+    parser = get_parser()
+    if args is None:
+        args = parser.parse_args()
 
     run_id = args.RunID
     run_dir_path = Path(args.run_dir)

--- a/ImProver/eval_improver.py
+++ b/ImProver/eval_improver.py
@@ -106,8 +106,8 @@ async def main_async(args):
 
 
 
-if __name__ == "__main__":
-
+def get_parser() -> argparse.ArgumentParser:
+    """Return the ``argparse`` parser used for evaluation."""
     parser = argparse.ArgumentParser(description="Generate prompts for ImProver")
     parser.add_argument("runID", type=str, help="Run ID to use for evaluation")
     parser.add_argument(
@@ -122,9 +122,11 @@ if __name__ == "__main__":
         default=multiprocessing.cpu_count(),
         help="Number of CPUs to use (default: all available)",
     )
+    return parser
 
 
+if __name__ == "__main__":
+    parser = get_parser()
     args = parser.parse_args()
-
     asyncio.run(main_async(args))
 

--- a/ImProver/get_prompts.py
+++ b/ImProver/get_prompts.py
@@ -142,12 +142,11 @@ async def main_async(args):
     progress_bar.close()
 
 
-if __name__ == "__main__":
-
+def get_parser() -> argparse.ArgumentParser:
+    """Return the ``argparse`` parser used by this module."""
     parser = argparse.ArgumentParser(description="Generate prompts for ImProver")
     parser.add_argument("dataset_path", type=str, help="Path to dataset JSON file")
-    parser.add_argument("--prompt_id", type=str, default="prompts_" + datetime.now().strftime("%Y%m%d_%H%M%S")),
-
+    parser.add_argument("--prompt_id", type=str, default="prompts_" + datetime.now().strftime("%Y%m%d_%H%M%S"))
     parser.add_argument(
         "--split",
         type=str,
@@ -178,10 +177,12 @@ if __name__ == "__main__":
         default=sys.executable,
         help="Python executable to use (default: current)",
     )
-    
-    args = parser.parse_args()
+    return parser
 
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
     make_config(args)
-    
     asyncio.run(main_async(args))
 

--- a/ImProver/improver.py
+++ b/ImProver/improver.py
@@ -1,18 +1,190 @@
+import asyncio
+import multiprocessing
+import os
+from types import SimpleNamespace
+from pathlib import Path
+from .get_prompts import make_config as gp_make_config, main_async as gp_main
+from .inference import main as inf_main
+from .eval_improver import main_async as eval_main
+from .readability import main as readability_main
+from .analysis import main as analysis_main
 
 
+def run_pipeline(config: dict):
+    """Run the full evaluation pipeline given a flat configuration dictionary."""
+
+    prompt_id = config.get("prompt_id")
+    if prompt_id is None:
+        gp_args = {k: config.get(k) for k in [
+            "dataset_path",
+            "prompt_id",
+            "split",
+            "prompts_dir",
+            "example_dir",
+            "cpus",
+            "python_cmd",
+        ]}
+        if gp_args.get("dataset_path") is None:
+            raise ValueError("dataset_path is required when prompt_id is not provided")
+        gp_args.setdefault("cpus", multiprocessing.cpu_count())
+        gp_args.setdefault("prompts_dir", ".prompts")
+        gp_args.setdefault("example_dir", ".prompts/.prompt_examples")
+        gp_args.setdefault("python_cmd", "python")
+        args = SimpleNamespace(**gp_args)
+        gp_make_config(args)
+        asyncio.run(gp_main(args))
+        prompt_id = args.prompt_id
+
+    inf_args = {k: config.get(k) for k in [
+        "metric",
+        "dataset_path",
+        "model",
+        "split",
+        "prompts_dir",
+        "output_dir",
+        "cpus",
+        "gpus",
+        "n",
+        "annotation",
+        "context",
+        "rag",
+        "examples",
+        "runID",
+    ]}
+    inf_args.setdefault("cpus", multiprocessing.cpu_count())
+    inf_args.setdefault("gpus", 0)
+    inf_args.setdefault("output_dir", ".evals/")
+    inf_args.setdefault("prompts_dir", ".prompts/")
+    inf_args.setdefault("split", "train")
+    inf_args["prompt_id"] = prompt_id
+    inf_ns = SimpleNamespace(**inf_args)
+    run_id = inf_main(inf_ns)
+
+    eval_args = {
+        "runID": run_id,
+        "inference_dir": config.get("inference_dir", inf_ns.output_dir),
+        "cpus": config.get("cpus", multiprocessing.cpu_count()),
+    }
+    eval_ns = SimpleNamespace(**eval_args)
+    asyncio.run(eval_main(eval_ns))
+
+    if inf_ns.metric == "readability":
+        read_ns = SimpleNamespace(
+            runID=run_id,
+            prompts_id=prompt_id,
+            inference=config.get("readability_inference", True),
+            model=config.get("model", "deepseek-ai/DeepSeek-Prover-V2-7B"),
+            split=config.get("split", "train"),
+            prompts_dir=config.get("prompts_dir", ".prompts/"),
+            output_dir=config.get("output_dir", ".evals/"),
+            cpus=config.get("cpus", multiprocessing.cpu_count()),
+            gpus=config.get("gpus", 0),
+            n=config.get("readability_n", 3),
+        )
+        readability_main(read_ns)
+
+    analysis_ns = SimpleNamespace(
+        RunID=run_id,
+        run_dir=config.get("run_dir", inf_ns.output_dir),
+        training_data=config.get("training_data", True),
+    )
+    analysis_main(analysis_ns)
+    return run_id
 
 
+def run_kg_pipeline(config: dict, insert: bool = True):
+    """Run the knowledge graph construction pipeline."""
 
+    prompt_id = config.get("prompts_id")
+    if prompt_id is None:
+        gp_args = {k: config.get(k) for k in [
+            "dataset_path",
+            "prompt_id",
+            "split",
+            "prompts_dir",
+            "example_dir",
+            "cpus",
+            "python_cmd",
+        ]}
+        if gp_args.get("dataset_path") is None:
+            raise ValueError("dataset_path is required when prompts_id is not provided")
+        gp_args.setdefault("cpus", multiprocessing.cpu_count())
+        gp_args.setdefault("prompts_dir", ".prompts")
+        gp_args.setdefault("example_dir", ".prompts/.prompt_examples")
+        gp_args.setdefault("python_cmd", "python")
+        args = SimpleNamespace(**gp_args)
+        gp_make_config(args)
+        asyncio.run(gp_main(args))
+        prompt_id = args.prompt_id
 
+    kg_id = config.get("KG_id", f"KG_{prompt_id}")
 
+    informalize_args = SimpleNamespace(
+        dataset_path=config.get("dataset_path"),
+        prompts_id=prompt_id,
+        split=config.get("split", "train"),
+        prompts_dir=config.get("prompts_dir", ".prompts"),
+        include_context=config.get("include_context", False),
+        model=config.get("model", "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"),
+        cpus=config.get("cpus", multiprocessing.cpu_count()),
+        gpus=config.get("gpus", 0),
+    )
+    from .KG import informalize as kg_informalize
 
+    kg_informalize.main(informalize_args)
 
+    from .KG import build_vector_db as kg_build_vector
+    build_vector_args = SimpleNamespace(
+        prompts_id=prompt_id,
+        KG_id=kg_id,
+        prompts_dir=config.get("prompts_dir", ".prompts"),
+        KG_dir=config.get("KG_dir", ".knowledge_graphs"),
+        model=config.get("embedding_model", "Qwen/Qwen3-Embedding-0.6B"),
+    )
+    kg_build_vector.main(build_vector_args)
 
+    from .KG import compute_class3_edges as kg_c3
+    c3_args = SimpleNamespace(
+        KG_id=kg_id,
+        KG_dir=config.get("KG_dir", ".knowledge_graphs"),
+        model=config.get("embedding_model", "Qwen/Qwen3-Embedding-0.6B"),
+        k=config.get("k", 40),
+        threshold=config.get("threshold", 0.35),
+    )
+    kg_c3.main(c3_args)
 
+    from .KG import build_combined_db as kg_combined
+    combine_args = SimpleNamespace(
+        dataset_path=config.get("dataset_path"),
+        KG_id=kg_id,
+        split=config.get("split", "train"),
+        KG_dir=config.get("KG_dir", ".knowledge_graphs"),
+    )
+    kg_combined.main(combine_args)
 
+    from .KG import heuristic_filter as kg_filter
+    filter_args = SimpleNamespace(
+        KG_id=kg_id,
+        KG_dir=config.get("KG_dir", ".knowledge_graphs"),
+        model=config.get("model", "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"),
+        cpus=config.get("cpus", multiprocessing.cpu_count()),
+        gpus=config.get("gpus", 0),
+        n=config.get("n", 1),
+        run_inference=config.get("run_inference", True),
+        augment_DB=config.get("augment_DB", True),
+        training_data=config.get("training_data", True),
+    )
+    kg_filter.main(filter_args)
 
+    if insert:
+        from .KG import insert_neo4j as kg_insert
+        insert_args = SimpleNamespace(
+            KG_id=kg_id,
+            KG_dir=config.get("KG_dir", ".knowledge_graphs"),
+            neo4j_uri=config.get("neo4j_uri", "bolt://localhost:7687"),
+            neo4j_user=config.get("neo4j_user", "neo4j"),
+            neo4j_pass=config.get("neo4j_pass", "12345678"),
+        )
+        kg_insert.main(insert_args)
 
-
-
-
-
+    return kg_id

--- a/ImProver/inference.py
+++ b/ImProver/inference.py
@@ -80,8 +80,8 @@ def run_inference(df, args, ray_init=True):
     )
     ds = vllm_processor(ds).materialize()
 
-    id = f"RUN_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
-    run_output_dir = os.path.join(args.output_dir, id)
+    run_id = args.runID or f"RUN_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    run_output_dir = os.path.join(args.output_dir, run_id)
     os.makedirs(run_output_dir, exist_ok=True)
 
     output_path = os.path.join(run_output_dir, "data")
@@ -95,6 +95,7 @@ def run_inference(df, args, ray_init=True):
         "context": args.context,
         "rag": args.rag,
         "model": args.model,
+        "run_id": run_id,
     }
 
     config_path = os.path.join(run_output_dir, "config.json")
@@ -112,7 +113,7 @@ def run_inference(df, args, ray_init=True):
     """
     )
 
-    return run_output_dir
+    return run_output_dir, run_id
 
 
 def construct_prompts(config_data, data, args):
@@ -189,7 +190,7 @@ def construct_prompts(config_data, data, args):
         if args.annotation:
             prompt += f"<ANNOTATION>\n{item['annotation']}\n</ANNOTATION>\n\n"
 
-        prompt += f"\n<CURRENT>\n{item['id']['content'] if args.metric!="completion" else item['content_sorry']}\n</CURRENT>\n\n"
+        prompt += f"\n<CURRENT>\n{item['id']['content'] if args.metric!='completion' else item['content_sorry']}\n</CURRENT>\n\n"
         prompt += "<IMPROVED>"
 
         data = {
@@ -257,17 +258,20 @@ def main(args):
     print(sum(data.values()))
 
     # returns the path to the directory containing run metadata and the parquet lake
-    output_path = run_inference(df, args)
+    output_path, run_id = run_inference(df, args)
+    print(f"Run stored at {output_path} with id {run_id}")
+    return run_id
 
     # we should also initialize + index the duckDB stuff
 
 
-if __name__ == "__main__":
-
+def get_parser() -> argparse.ArgumentParser:
+    """Return the ``argparse`` parser used for inference."""
     parser = argparse.ArgumentParser(description="Generate prompts for ImProver")
     parser.add_argument("metric", type=str, help="Metric to use for evaluation")
     parser.add_argument("dataset_path", type=str, help="Path to dataset JSON file")
     parser.add_argument("prompt_id", type=str, help="Prompt ID to use")
+    parser.add_argument("--runID", type=str, default=None, help="Optional run identifier")
     parser.add_argument(
         "--model",
         type=str,
@@ -329,7 +333,10 @@ if __name__ == "__main__":
         default=0,
         help="Number of few-shot example retrievals (default: 0)",
     )
+    return parser
 
+
+if __name__ == "__main__":
+    parser = get_parser()
     args = parser.parse_args()
-
     main(args)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,32 @@ newly discovered results, produce JSONL files containing training data for both
 models in `cotraining_data/`, and save updated model checkpoints in
 `cotraining_models/`.
 
+## Command Line Interface
+
+The `improver_cli.py` script provides a simple interface for running the main
+pipelines. Each command reuses the argument parser of the underlying Python
+module so any updates to the scripts are automatically reflected in the CLI.
+An executable wrapper named `improver` is included so you can call
+the CLI directly once the repository root is on your `PATH`. After installing
+the dependencies you can invoke:
+
+```bash
+# generate prompts
+improver get_prompts --config configs/run_example.yaml
+
+# run the full evaluation pipeline
+improver run --config configs/run_example.yaml
+
+# knowledge graph utilities
+improver KG run --config configs/kg_example.yaml
+improver KG data --config configs/kg_example.yaml  # without Neo4j insertion
+improver KG insert --config configs/kg_example.yaml  # insert only
+```
+
+Each command accepts a flat YAML config with fields matching the command line
+options of the underlying script. Example configs are provided in the `configs/`
+directory as `run_example.yaml` and `kg_example.yaml`.
+
 ## Acknowledgements
 We would like to thank Kim Morrison for the [Training Data repository](https://github.com/semorrison/lean-training-data) and Sean Welleck for the [Neural Theorem Proving (NTP) toolkit repository](https://github.com/cmu-l3/ntp-toolkit), which served as foundational resources for this project. Additionally, we would like to thank the Paperproof team for the [Paperproof repository](https://github.com/Paper-Proof/paperproof), which paved the way for our own prooftree generation and analysis system.
 

--- a/configs/kg_example.yaml
+++ b/configs/kg_example.yaml
@@ -1,0 +1,23 @@
+# Example configuration for `improver KG run`
+# Keys correspond to command line options of the KG pipeline.
+
+dataset_path: train/data/train/final_dataset.json
+prompts_id: demo_prompts
+KG_id: demo_kg
+split: train
+prompts_dir: .prompts
+KG_dir: .knowledge_graphs
+include_context: false
+model: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+embedding_model: Qwen/Qwen3-Embedding-0.6B
+k: 40
+threshold: 0.35
+cpus: 4
+gpus: 1
+n: 1
+run_inference: true
+augment_DB: true
+training_data: true
+neo4j_uri: bolt://localhost:7687
+neo4j_user: neo4j
+neo4j_pass: 12345678

--- a/configs/run_example.yaml
+++ b/configs/run_example.yaml
@@ -1,0 +1,16 @@
+# Example configuration for `improver run`
+# Each key corresponds to a command line option.
+
+dataset_path: train/data/train/final_dataset.json
+prompt_id: demo_prompts
+metric: readability
+model: deepseek-ai/DeepSeek-Prover-V2-7B
+split: train
+prompts_dir: .prompts
+example_dir: .prompts/.prompt_examples
+output_dir: .evals
+cpus: 4
+gpus: 1
+n: 1
+readability_n: 3
+training_data: true

--- a/improver
+++ b/improver
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from improver_cli import app
+
+if __name__ == "__main__":
+    app()

--- a/improver_cli.py
+++ b/improver_cli.py
@@ -1,0 +1,160 @@
+import asyncio
+import argparse
+import multiprocessing
+import sys
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+import typer
+import yaml
+
+from ImProver.get_prompts import get_parser as gp_parser, make_config as gp_make_config, main_async as gp_main
+from ImProver.inference import get_parser as inf_parser, main as inf_main
+from ImProver.eval_improver import get_parser as eval_parser, main_async as eval_main
+from ImProver.analysis import get_parser as analysis_parser, main as analysis_main
+from ImProver.readability import get_parser as read_parser, main as readability_main
+from ImProver.improver import run_pipeline, run_kg_pipeline
+from ImProver.KG.informalize import get_parser as kg_inf_parser
+from ImProver.KG.build_vector_db import get_parser as kg_build_parser
+from ImProver.KG.compute_class3_edges import get_parser as kg_c3_parser
+from ImProver.KG.build_combined_db import get_parser as kg_combined_parser
+from ImProver.KG.heuristic_filter import get_parser as kg_filter_parser
+from ImProver.KG.insert_neo4j import get_parser as kg_insert_parser
+
+app = typer.Typer(help="Command line interface for the ImProver research framework")
+kg_app = typer.Typer(help="Knowledge graph utilities")
+app.add_typer(kg_app, name="KG")
+
+
+def load_config(path: Path) -> dict:
+    if path is None:
+        return {}
+    with open(path, "r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _config_to_args(parser: argparse.ArgumentParser, cfg: dict) -> list[str]:
+    args = []
+    for act in parser._actions:
+        if act.dest == "help":
+            continue
+        if act.dest in cfg and cfg[act.dest] is not None:
+            val = cfg[act.dest]
+            if not act.option_strings:
+                args.append(str(val))
+            elif isinstance(act, argparse._BooleanOptionalAction):
+                if val:
+                    args.append(act.option_strings[0])
+                else:
+                    if len(act.option_strings) > 1:
+                        args.append(act.option_strings[1])
+            elif act.nargs == 0:
+                if val:
+                    args.append(act.option_strings[0])
+            else:
+                args.append(act.option_strings[0])
+                args.append(str(val))
+    return args
+
+
+def _parse_with_config(parser_func, extras: list[str], cfg: dict) -> argparse.Namespace:
+    parser = parser_func()
+    if "--help" in extras or "-h" in extras:
+        parser.print_help()
+        raise typer.Exit()
+    args = _config_to_args(parser, cfg) + extras
+    return parser.parse_args(args)
+
+
+def _combine_parsers(*parsers: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    combined = argparse.ArgumentParser(add_help=False)
+    seen = set()
+    for p in parsers:
+        for a in p._actions:
+            if a.dest == "help" or a.dest in seen:
+                continue
+            params = {
+                "help": a.help,
+                "default": a.default,
+                "nargs": a.nargs,
+                "choices": getattr(a, "choices", None),
+                "type": getattr(a, "type", None),
+                "action": a.__class__ if a.option_strings else None,
+                "metavar": a.metavar,
+            }
+            params = {k: v for k, v in params.items() if v is not None}
+            if a.option_strings:
+                combined.add_argument(*a.option_strings, **params)
+            else:
+                combined.add_argument(a.dest, **params)
+            seen.add(a.dest)
+    return combined
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def get_prompts(ctx: typer.Context, config: Path = typer.Option(None, help="YAML config")):
+    cfg = load_config(config)
+    ns = _parse_with_config(gp_parser, ctx.args, cfg)
+    gp_make_config(ns)
+    asyncio.run(gp_main(ns))
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def inference(ctx: typer.Context, config: Path = typer.Option(None, help="YAML config")):
+    cfg = load_config(config)
+    ns = _parse_with_config(inf_parser, ctx.args, cfg)
+    inf_main(ns)
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def eval(ctx: typer.Context, config: Path = typer.Option(None, help="YAML config")):
+    cfg = load_config(config)
+    ns = _parse_with_config(eval_parser, ctx.args, cfg)
+    asyncio.run(eval_main(ns))
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def analysis(ctx: typer.Context, config: Path = typer.Option(None, help="YAML config")):
+    cfg = load_config(config)
+    ns = _parse_with_config(analysis_parser, ctx.args, cfg)
+    analysis_main(ns)
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def run(ctx: typer.Context, config: Path = typer.Option(..., help="YAML config")):
+    cfg = load_config(config)
+    union = _combine_parsers(gp_parser(), inf_parser(), eval_parser(), analysis_parser(), read_parser())
+    ns = union.parse_args(_config_to_args(union, cfg) + ctx.args)
+    run_id = run_pipeline(vars(ns))
+    typer.echo(f"Run ID: {run_id}")
+
+
+@kg_app.command("data", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def kg_data(ctx: typer.Context, config: Path = typer.Option(..., help="YAML config")):
+    cfg = load_config(config)
+    union = _combine_parsers(kg_inf_parser(), kg_build_parser(), kg_c3_parser(), kg_combined_parser(), kg_filter_parser())
+    ns = union.parse_args(_config_to_args(union, cfg) + ctx.args)
+    kg_id = run_kg_pipeline(vars(ns), insert=False)
+    typer.echo(f"KG ID: {kg_id}")
+
+
+@kg_app.command("insert", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def kg_insert(ctx: typer.Context, config: Path = typer.Option(..., help="YAML config")):
+    cfg = load_config(config)
+    ns = _parse_with_config(kg_insert_parser, ctx.args, cfg)
+    from ImProver.KG import insert_neo4j as kg_insert_mod
+    kg_insert_mod.main(ns)
+
+
+@kg_app.command("run", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def kg_run(ctx: typer.Context, config: Path = typer.Option(..., help="YAML config")):
+    cfg = load_config(config)
+    union = _combine_parsers(kg_inf_parser(), kg_build_parser(), kg_c3_parser(), kg_combined_parser(), kg_filter_parser(), kg_insert_parser())
+    ns = union.parse_args(_config_to_args(union, cfg) + ctx.args)
+    kg_id = run_kg_pipeline(vars(ns), insert=True)
+    typer.echo(f"KG ID: {kg_id}")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- expose `get_parser` in knowledge graph utilities
- implement `run_kg_pipeline` and KG commands in the CLI
- document new KG options in README and example config

## Testing
- `python -m py_compile improver_cli.py improver ImProver/inference.py ImProver/improver.py ImProver/get_prompts.py ImProver/eval_improver.py ImProver/analysis.py ImProver/KG/informalize.py ImProver/KG/build_vector_db.py ImProver/KG/compute_class3_edges.py ImProver/KG/build_combined_db.py ImProver/KG/heuristic_filter.py ImProver/KG/insert_neo4j.py`

------
https://chatgpt.com/codex/tasks/task_e_685edd09179c83308af5782acaf6d20f